### PR TITLE
update to use min supported python version for PL

### DIFF
--- a/version_bump_action/action.yml
+++ b/version_bump_action/action.yml
@@ -32,7 +32,7 @@ runs:
     - name: Install Python
       uses: actions/setup-python@v2
       with:
-        python-version: '3.9'
+        python-version: '3.11'
 
     - name: Install dependencies
       run: |


### PR DESCRIPTION
During the release process I was using this automation script to do some version bumps of our plug-ins. However, because the python version was 3.9 it was actually installing pennylane 0.38 rather than the latest version lol.

This caused an incorrect commit to my PR: https://github.com/PennyLaneAI/pennylane-aqt/pull/92/commits/3b6350fe3f45132c23c98dd7c1d5f25f9c6f1e3d